### PR TITLE
Hide find my ingredients button and initial text field once ingredients have been found, with option to detect again

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -94,6 +94,11 @@ class RecipesController < ApplicationController
     # Render the form for uploading an image
   end
 
+  def clear_ingredients
+    session.delete(:detected_ingredients)
+    redirect_to detect_ingredients_recipes_path
+  end
+
   def process_image
     manual_ingredients = processed_manual_ingredients(params)
 

--- a/app/views/recipes/detect_ingredients.html.erb
+++ b/app/views/recipes/detect_ingredients.html.erb
@@ -2,59 +2,61 @@
   <%= render 'shared/header', title: '' %>
 
   <div class="mt-4">
-    <%= form_with(url: process_image_recipes_path, method: :post, multipart: true, class: "needs-validation", data: { action: 'submit->ingredient-detection#formSubmitting' }) do |form| %>
-      <div class="form-group mb-4 text-center">
-        <div data-ingredient-detection-target="uploadButton">
-          <label for="image-upload" class="btn btn-primary btn-lg rounded-pill shadow-sm mb-3">
-            <i class="fa-solid fa-plus"></i> Take a pic or upload an image
-          </label>
+    <% unless session[:detected_ingredients].present? %>
+      <%= form_with(url: process_image_recipes_path, method: :post, multipart: true, class: "needs-validation", data: { action: 'submit->ingredient-detection#formSubmitting' }) do |form| %>
+        <div class="form-group mb-4 text-center">
+          <div data-ingredient-detection-target="uploadButton">
+            <label for="image-upload" class="btn btn-primary btn-lg rounded-pill shadow-sm mb-3">
+              <i class="fa-solid fa-plus"></i> Take a pic or upload an image
+            </label>
+          </div>
+          <div class="d-none" data-ingredient-detection-target="imagePreview">
+            <img src="about:blank" alt="Selected image"
+                 class="rounded mb-2 shadow-sm"
+                 style="max-height: 140px; max-width: 140px; object-fit: cover;"
+                 data-ingredient-detection-target="previewImg">
+            <p class="text-muted small mb-2" data-ingredient-detection-target="fileName"></p>
+            <label for="image-upload" class="btn btn-outline-secondary btn-sm rounded-pill">
+              <i class="fa-solid fa-rotate"></i> Change photo
+            </label>
+          </div>
+          <%= form.file_field :image,
+                id: "image-upload",
+                accept: "image/*",
+                class: "d-none",
+                data: {
+                  'ingredient-detection-target': 'imageUpload',
+                  action: 'change->ingredient-detection#imageSelected'
+                } %>
         </div>
-        <div class="d-none" data-ingredient-detection-target="imagePreview">
-          <img src="about:blank" alt="Selected image"
-               class="rounded mb-2 shadow-sm"
-               style="max-height: 140px; max-width: 140px; object-fit: cover;"
-               data-ingredient-detection-target="previewImg">
-          <p class="text-muted small mb-2" data-ingredient-detection-target="fileName"></p>
-          <label for="image-upload" class="btn btn-outline-secondary btn-sm rounded-pill">
-            <i class="fa-solid fa-rotate"></i> Change photo
+
+        <div class="form-group mb-4">
+          <label for="manual_ingredients" class="form-label text-center w-100 fw-semibold">
+            Or enter ingredients manually
           </label>
+          <%= form.text_field :manual_ingredients,
+                id: "manual_ingredients",
+                placeholder: "e.g., tomatoes, basil, mozzarella",
+                class: "form-control form-control-lg rounded-pill shadow-sm",
+                data: {
+                  'ingredient-detection-target': 'manualInput',
+                  action: 'input->ingredient-detection#manualInputChanged'
+                } %>
+          <small class="form-text text-muted text-center d-block mt-2">
+            Separate multiple ingredients with commas.
+          </small>
         </div>
-        <%= form.file_field :image,
-              id: "image-upload",
-              accept: "image/*",
-              class: "d-none",
-              data: {
-                'ingredient-detection-target': 'imageUpload',
-                action: 'change->ingredient-detection#imageSelected'
-              } %>
-      </div>
 
-      <div class="form-group mb-4">
-        <label for="manual_ingredients" class="form-label text-center w-100 fw-semibold">
-          Or enter ingredients manually
-        </label>
-        <%= form.text_field :manual_ingredients,
-              id: "manual_ingredients",
-              placeholder: "e.g., tomatoes, basil, mozzarella",
-              class: "form-control form-control-lg rounded-pill shadow-sm",
-              data: {
-                'ingredient-detection-target': 'manualInput',
-                action: 'input->ingredient-detection#manualInputChanged'
-              } %>
-        <small class="form-text text-muted text-center d-block mt-2">
-          Separate multiple ingredients with commas.
-        </small>
-      </div>
-
-      <div class="d-flex justify-content-center">
-        <%= form.button "Find my ingredients",
-              type: "submit",
-              class: 'btn btn-primary btn-lg rounded-pill shadow-sm mb-3',
-              data: {
-                'ingredient-detection-target': 'detectButton'
-              },
-              disabled: true %>
-      </div>
+        <div class="d-flex justify-content-center">
+          <%= form.button "Find my ingredients",
+                type: "submit",
+                class: 'btn btn-primary btn-lg rounded-pill shadow-sm mb-3',
+                data: {
+                  'ingredient-detection-target': 'detectButton'
+                },
+                disabled: true %>
+        </div>
+      <% end %>
     <% end %>
 
     <% if session[:detected_ingredients].present? %>

--- a/app/views/recipes/detect_ingredients.html.erb
+++ b/app/views/recipes/detect_ingredients.html.erb
@@ -2,7 +2,8 @@
   <%= render 'shared/header', title: '' %>
 
   <div class="mt-4">
-    <% unless session[:detected_ingredients].present? %>
+    <% detected = session[:detected_ingredients].presence %>
+    <% if detected.nil? %>
       <%= form_with(url: process_image_recipes_path, method: :post, multipart: true, class: "needs-validation", data: { action: 'submit->ingredient-detection#formSubmitting' }) do |form| %>
         <div class="form-group mb-4 text-center">
           <div data-ingredient-detection-target="uploadButton">
@@ -57,9 +58,7 @@
                 disabled: true %>
         </div>
       <% end %>
-    <% end %>
-
-    <% if session[:detected_ingredients].present? %>
+    <% else %>
       <%= form_with(url: recipes_path, method: :get, local: true) do |form| %>
         <div class="mt-5">
           <h2 class="text-center">Voila!</h2>
@@ -76,7 +75,7 @@
           </div>
 
           <div class="list-group mt-3">
-            <% session[:detected_ingredients].split(',').each_with_index do |ingredient, index| %>
+            <% detected.split(',').each_with_index do |ingredient, index| %>
               <div class="list-group-item py-3 px-3 rounded-pill shadow-sm border d-flex align-items-center justify-content-between mb-2">
                 <label class="d-flex align-items-center flex-grow-1">
                   <%= check_box_tag 'selected_ingredients[]', ingredient.strip, true,

--- a/app/views/recipes/detect_ingredients.html.erb
+++ b/app/views/recipes/detect_ingredients.html.erb
@@ -59,6 +59,10 @@
         </div>
       <% end %>
     <% else %>
+      <div class="d-flex justify-content-end mb-3">
+        <%= button_to "Detect again", clear_ingredients_recipes_path, method: :delete,
+              class: "btn btn-outline-secondary btn-sm rounded-pill shadow-sm" %>
+      </div>
       <%= form_with(url: recipes_path, method: :get, local: true) do |form| %>
         <div class="mt-5">
           <h2 class="text-center">Voila!</h2>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
 
     # Add a custom POST route with a named route
     post 'process_image', to: 'recipes#process_image', on: :collection, as: :process_image
+    delete 'clear_ingredients', to: 'recipes#clear_ingredients', on: :collection, as: :clear_ingredients
   end
 
   resources :favorites, only: [:index]


### PR DESCRIPTION
Updates the ingredient-detection page so the initial upload/enter ingredients form is only shown before any ingredients have been detected, and the results UI is shown afterward. Users can also restart the detection process at any time.

## Changes Made

- **Single if/else control flow**: Refactored `detect_ingredients.html.erb` to assign `detected = session[:detected_ingredients].presence` once and use a single `if/else` block, eliminating duplicate `present?` checks.
- **Detect again button**: Added a "Detect again" button on the results page that clears `session[:detected_ingredients]` and returns the user to the initial detection form.
- **New route**: Added `DELETE recipes/clear_ingredients` route.
- **New controller action**: Added `clear_ingredients` action to `RecipesController` that deletes the session key and redirects to the detection page.