### PR TITLE
Added unsplash images for recipes where possible

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -182,17 +182,14 @@ class RecipesController < ApplicationController
   private
 
   def enrich_posts_with_unsplash_images
-    threads = @posts.map do |post|
-      Thread.new do
-        urls = UnsplashImageService.fetch(post["title"])
-        if urls
-          post["unsplash_small"]             = urls[:small]
-          post["unsplash_photographer_name"] = urls[:photographer_name]
-          post["unsplash_photographer_url"]  = urls[:photographer_url]
-        end
-      end
+    @posts.each do |post|
+      urls = UnsplashImageService.fetch(post["title"])
+      next unless urls
+
+      post["unsplash_small"]             = urls[:small]
+      post["unsplash_photographer_name"] = urls[:photographer_name]
+      post["unsplash_photographer_url"]  = urls[:photographer_url]
     end
-    threads.each(&:join)
   end
 
   def recipe_params

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -21,6 +21,7 @@ class RecipesController < ApplicationController
       @posts = []
       response = URI.parse(url).read
       @posts = JSON.parse(response)
+      enrich_posts_with_unsplash_images
     rescue OpenURI::HTTPError => e
       # Handle errors (e.g., API down, invalid URL)
       @posts = []
@@ -37,6 +38,12 @@ class RecipesController < ApplicationController
     begin
       response = URI.parse(url).read
       @recipe = JSON.parse(response)
+      urls = UnsplashImageService.fetch(@recipe["title"])
+      if urls
+        @unsplash_image_url      = urls[:regular]
+        @unsplash_attribution    = { name: urls[:photographer_name], url: urls[:photographer_url] }
+        UnsplashImageService.trigger_download(urls[:download_location])
+      end
 
     rescue OpenURI::HTTPError => e
       flash[:error] = "Unable to fetch recipe details: #{e.message}"
@@ -66,13 +73,16 @@ class RecipesController < ApplicationController
 
       # Build the recipe in the database
       @recipe = Recipe.find_or_initialize_by(id: recipe_id)
+      unsplash_urls = UnsplashImageService.fetch(recipe_data["title"])
+      best_image = unsplash_urls&.fetch(:regular).presence || recipe_data["image"]
+
       @recipe.assign_attributes(
         name: recipe_data["title"],
         description: recipe_data["summary"],
         ingredients: recipe_data["extendedIngredients"]&.map { |i| i["original"] }&.join("\n"),
         cooking_time: recipe_data["readyInMinutes"],
         rating: (recipe_data["spoonacularScore"].to_f / 20).round(1),
-        image: recipe_data["image"],
+        image: best_image,
         search_id: Search.first.id # Ensure this matches your schema
       )
 
@@ -170,6 +180,20 @@ class RecipesController < ApplicationController
   end
 
   private
+
+  def enrich_posts_with_unsplash_images
+    threads = @posts.map do |post|
+      Thread.new do
+        urls = UnsplashImageService.fetch(post["title"])
+        if urls
+          post["unsplash_small"]             = urls[:small]
+          post["unsplash_photographer_name"] = urls[:photographer_name]
+          post["unsplash_photographer_url"]  = urls[:photographer_url]
+        end
+      end
+    end
+    threads.each(&:join)
+  end
 
   def recipe_params
     params.permit(:image)

--- a/app/services/unsplash_image_service.rb
+++ b/app/services/unsplash_image_service.rb
@@ -1,0 +1,63 @@
+require "net/http"
+
+class UnsplashImageService
+  CACHE_TTL = 7.days
+  BASE_URL  = "https://api.unsplash.com/search/photos"
+
+  def self.fetch(recipe_title)
+    new(recipe_title).fetch
+  end
+
+  # Must be called when a user views/uses a photo — Unsplash API requirement.
+  def self.trigger_download(download_location)
+    return if download_location.blank?
+    Thread.new do
+      uri = URI(download_location)
+      uri.query = [uri.query, URI.encode_www_form(client_id: ENV["UNSPLASH_ACCESS_KEY"])].compact.join("&")
+      Net::HTTP.get_response(uri)
+    rescue StandardError => e
+      Rails.logger.warn("UnsplashImageService download trigger failed: #{e.message}")
+    end
+  end
+
+  def initialize(recipe_title)
+    @recipe_title = recipe_title
+  end
+
+  def fetch
+    Rails.cache.fetch(cache_key, expires_in: CACHE_TTL) { fetch_from_unsplash }
+  end
+
+  private
+
+  def cache_key
+    "unsplash/#{@recipe_title.downcase.gsub(/\s+/, '_').gsub(/[^a-z0-9_]/, '')}"
+  end
+
+  def fetch_from_unsplash
+    uri = URI(BASE_URL)
+    uri.query = URI.encode_www_form(
+      query:          @recipe_title,
+      per_page:       1,
+      orientation:    "landscape",
+      content_filter: "high",
+      client_id:      ENV["UNSPLASH_ACCESS_KEY"]
+    )
+    response = Net::HTTP.get_response(uri)
+    return nil unless response.is_a?(Net::HTTPSuccess)
+
+    result = JSON.parse(response.body).dig("results", 0)
+    return nil if result.nil?
+
+    {
+      regular:           result.dig("urls", "regular"),
+      small:             result.dig("urls", "small"),
+      download_location: result.dig("links", "download_location"),
+      photographer_name: result.dig("user", "name"),
+      photographer_url:  result.dig("user", "links", "html")
+    }
+  rescue StandardError => e
+    Rails.logger.warn("UnsplashImageService failed for '#{@recipe_title}': #{e.message}")
+    nil
+  end
+end

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -6,40 +6,38 @@
       <% @posts.each do |post| %>
         <div class="col-12 col-md-6 col-xl-4">
           <div class="border-0 shadow-lg rounded-4 h-100 position-relative">
-            <a href="<%= recipe_path(post["id"]) %>" class="stretched-link text-decoration-none">
-              <div class="position-relative p-2 favorite-card rounded-top-4">
-                <% img_src = post["unsplash_small"].presence || spoonacular_image_url(post["image"]).presence || "https://via.placeholder.com/636x393" %>
-                <img src="<%= img_src %>" alt="<%= post["title"] %>" class="card-img-top rounded-4 object-fit-cover w-100" style="height:220px" loading="lazy" />
-                <% photographer_name = post["unsplash_photographer_name"] %>
-                <% photographer_url = post["unsplash_photographer_url"] %>
-                <% if photographer_name.present? && photographer_url.present? %>
-                  <% separator = photographer_url.include?("?") ? "&" : "?" %>
-                  <% attribution_url = "#{photographer_url}#{separator}utm_source=matchmeal&utm_medium=referral" %>
-                  <a href="<%= attribution_url %>"
-                     target="_blank" rel="noopener noreferrer"
-                     class="position-absolute bottom-0 end-0 mb-2 me-3 text-white text-decoration-none z-1"
-                     style="font-size:0.65rem; text-shadow:0 1px 3px rgba(0,0,0,0.7);"
-                     onclick="event.stopPropagation()">
-                    <%= photographer_name %> / <span class="text-decoration-underline">Unsplash</span>
-                  </a>
-                <% end %>
-              </div>
+            <a href="<%= recipe_path(post["id"]) %>" class="stretched-link text-decoration-none"></a>
+            <div class="position-relative p-2 favorite-card rounded-top-4">
+              <% img_src = post["unsplash_small"].presence || spoonacular_image_url(post["image"]).presence || "https://via.placeholder.com/636x393" %>
+              <img src="<%= img_src %>" alt="<%= post["title"] %>" class="card-img-top rounded-4 object-fit-cover w-100" style="height:220px" loading="lazy" />
+              <% photographer_name = post["unsplash_photographer_name"] %>
+              <% photographer_url = post["unsplash_photographer_url"] %>
+              <% if photographer_name.present? && photographer_url.present? %>
+                <% separator = photographer_url.include?("?") ? "&" : "?" %>
+                <% attribution_url = "#{photographer_url}#{separator}utm_source=matchmeal&utm_medium=referral" %>
+                <a href="<%= attribution_url %>"
+                   target="_blank" rel="noopener noreferrer"
+                   class="position-absolute bottom-0 end-0 mb-2 me-3 text-white text-decoration-none"
+                   style="font-size:0.65rem; text-shadow:0 1px 3px rgba(0,0,0,0.7); z-index: 2;">
+                  <%= photographer_name %> / <span class="text-decoration-underline">Unsplash</span>
+                </a>
+              <% end %>
+            </div>
 
-              <div class="favorite-body text-center bg-my-dark-blue text-white p-4" style="border-radius: 0 0 15px 15px;">
-                <h5 class="card-title text-my-yellow mb-3 d-flex justify-content-center align-items-center gap-2">
-                  <span class="text-start"><%= post["title"] %></span>
+            <div class="favorite-body text-center bg-my-dark-blue text-white p-4" style="border-radius: 0 0 15px 15px;">
+              <h5 class="card-title text-my-yellow mb-3 d-flex justify-content-center align-items-center gap-2">
+                <span class="text-start"><%= post["title"] %></span>
 
-                </h5>
+              </h5>
 
-                <p class="card-text text-center mb-2">
-                  <i class="fas fa-utensils text-primary"></i> <strong>Used ingredients: <%= post["usedIngredientCount"] %></strong>
-                </p>
-                <p class="card-text text-center mb-2">
-                  <i class="fas fa-exclamation-circle text-primary"></i> <strong>Missing ingredients: <%= post["missedIngredientCount"] %></strong>
-                </p>
+              <p class="card-text text-center mb-2">
+                <i class="fas fa-utensils text-primary"></i> <strong>Used ingredients: <%= post["usedIngredientCount"] %></strong>
+              </p>
+              <p class="card-text text-center mb-2">
+                <i class="fas fa-exclamation-circle text-primary"></i> <strong>Missing ingredients: <%= post["missedIngredientCount"] %></strong>
+              </p>
 
-              </div>
-            </a>
+            </div>
           </div>
         </div>
       <% end %>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -8,10 +8,16 @@
           <div class="border-0 shadow-lg rounded-4 h-100 position-relative">
             <a href="<%= recipe_path(post["id"]) %>" class="stretched-link text-decoration-none">
               <div class="position-relative p-2 favorite-card rounded-top-4">
-                <% if post["image"].present? %>
-                  <img src="<%= spoonacular_image_url(post["image"]) %>" alt="<%= post["title"] %>" class="card-img-top rounded-4 object-fit-cover w-100" style="height:220px" />
-                <% else %>
-                  <img src="https://via.placeholder.com/636x393" alt="Recipe image" class="card-img-top rounded-4 object-fit-cover w-100" style="height:220px" />
+                <% img_src = post["unsplash_small"].presence || spoonacular_image_url(post["image"]).presence || "https://via.placeholder.com/636x393" %>
+                <img src="<%= img_src %>" alt="<%= post["title"] %>" class="card-img-top rounded-4 object-fit-cover w-100" style="height:220px" loading="lazy" />
+                <% if post["unsplash_photographer_name"].present? %>
+                  <a href="<%= post["unsplash_photographer_url"] %>?utm_source=matchmeal&utm_medium=referral"
+                     target="_blank" rel="noopener noreferrer"
+                     class="position-absolute bottom-0 end-0 mb-2 me-3 text-white text-decoration-none z-1"
+                     style="font-size:0.65rem; text-shadow:0 1px 3px rgba(0,0,0,0.7);"
+                     onclick="event.stopPropagation()">
+                    <%= post["unsplash_photographer_name"] %> / <span class="text-decoration-underline">Unsplash</span>
+                  </a>
                 <% end %>
               </div>
 

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -10,13 +10,17 @@
               <div class="position-relative p-2 favorite-card rounded-top-4">
                 <% img_src = post["unsplash_small"].presence || spoonacular_image_url(post["image"]).presence || "https://via.placeholder.com/636x393" %>
                 <img src="<%= img_src %>" alt="<%= post["title"] %>" class="card-img-top rounded-4 object-fit-cover w-100" style="height:220px" loading="lazy" />
-                <% if post["unsplash_photographer_name"].present? %>
-                  <a href="<%= post["unsplash_photographer_url"] %>?utm_source=matchmeal&utm_medium=referral"
+                <% photographer_name = post["unsplash_photographer_name"] %>
+                <% photographer_url = post["unsplash_photographer_url"] %>
+                <% if photographer_name.present? && photographer_url.present? %>
+                  <% separator = photographer_url.include?("?") ? "&" : "?" %>
+                  <% attribution_url = "#{photographer_url}#{separator}utm_source=matchmeal&utm_medium=referral" %>
+                  <a href="<%= attribution_url %>"
                      target="_blank" rel="noopener noreferrer"
                      class="position-absolute bottom-0 end-0 mb-2 me-3 text-white text-decoration-none z-1"
                      style="font-size:0.65rem; text-shadow:0 1px 3px rgba(0,0,0,0.7);"
                      onclick="event.stopPropagation()">
-                    <%= post["unsplash_photographer_name"] %> / <span class="text-decoration-underline">Unsplash</span>
+                    <%= photographer_name %> / <span class="text-decoration-underline">Unsplash</span>
                   </a>
                 <% end %>
               </div>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -6,7 +6,7 @@
       <% @posts.each do |post| %>
         <div class="col-12 col-md-6 col-xl-4">
           <div class="border-0 shadow-lg rounded-4 h-100 position-relative">
-            <a href="<%= recipe_path(post["id"]) %>" class="stretched-link text-decoration-none"></a>
+            <a href="<%= recipe_path(post["id"]) %>" class="stretched-link text-decoration-none" aria-label="View recipe: <%= post["title"] %>"></a>
             <div class="position-relative p-2 favorite-card rounded-top-4">
               <% img_src = post["unsplash_small"].presence || spoonacular_image_url(post["image"]).presence || "https://via.placeholder.com/636x393" %>
               <img src="<%= img_src %>" alt="<%= post["title"] %>" class="card-img-top rounded-4 object-fit-cover w-100" style="height:220px" loading="lazy" />

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -24,8 +24,19 @@
           <% end %>
 
           <!-- Recipe Image -->
-          <% if @recipe["image"].present? %>
-            <img src="<%= @recipe["image"] %>" alt="<%= @recipe["title"] %>" class="banner-image">
+          <% img_src = @unsplash_image_url.presence || @recipe["image"].presence %>
+          <% if img_src.present? %>
+            <div class="position-relative">
+              <img src="<%= img_src %>" alt="<%= @recipe["title"] %>" class="banner-image">
+              <% if @unsplash_attribution&.dig(:name).present? %>
+                <a href="<%= @unsplash_attribution[:url] %>?utm_source=matchmeal&utm_medium=referral"
+                   target="_blank" rel="noopener noreferrer"
+                   class="position-absolute bottom-0 end-0 mb-2 me-2 text-white text-decoration-none"
+                   style="font-size:0.7rem; text-shadow:0 1px 3px rgba(0,0,0,0.7);">
+                  Photo by <%= @unsplash_attribution[:name] %> on <span class="text-decoration-underline">Unsplash</span>
+                </a>
+              <% end %>
+            </div>
           <% else %>
             <div class="bg-secondary w-100 h-100 banner-placeholder text-white text-center d-flex align-items-center justify-content-center">
               <p><em>No image available for this recipe.</em></p>

--- a/app/views/recipes/show.html.erb
+++ b/app/views/recipes/show.html.erb
@@ -28,12 +28,16 @@
           <% if img_src.present? %>
             <div class="position-relative">
               <img src="<%= img_src %>" alt="<%= @recipe["title"] %>" class="banner-image">
-              <% if @unsplash_attribution&.dig(:name).present? %>
-                <a href="<%= @unsplash_attribution[:url] %>?utm_source=matchmeal&utm_medium=referral"
+              <% attribution_name = @unsplash_attribution&.dig(:name) %>
+              <% attribution_url = @unsplash_attribution&.dig(:url) %>
+              <% if attribution_name.present? && attribution_url.present? %>
+                <% attribution_separator = attribution_url.include?("?") ? "&" : "?" %>
+                <% attribution_href = "#{attribution_url}#{attribution_separator}utm_source=matchmeal&utm_medium=referral" %>
+                <a href="<%= attribution_href %>"
                    target="_blank" rel="noopener noreferrer"
                    class="position-absolute bottom-0 end-0 mb-2 me-2 text-white text-decoration-none"
                    style="font-size:0.7rem; text-shadow:0 1px 3px rgba(0,0,0,0.7);">
-                  Photo by <%= @unsplash_attribution[:name] %> on <span class="text-decoration-underline">Unsplash</span>
+                  Photo by <%= attribution_name %> on <span class="text-decoration-underline">Unsplash</span>
                 </a>
               <% end %>
             </div>


### PR DESCRIPTION
- [x] Analyze feedback: nested `<a>` in index.html.erb (comment #3032871162)
- [x] Fix index.html.erb: restructure card to use empty `stretched-link` `<a>` so the attribution link is no longer nested inside the card anchor — attribution `<a>` is now a sibling with `z-index: 2` to remain independently clickable above the stretched-link pseudo-element; removed `onclick="event.stopPropagation()"` workaround
- [x] Run final validation (CodeQL: 0 alerts, Code Review: ✅)